### PR TITLE
Don't target empty vehicles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
 Makes SAM Sites act in a similar fashion to shotgun traps and flame turrets by checking if players operating vehicles are authorized on the cupboard.
 
-Also prevents these SAM Sites from shooting cold vehicles (defined entities without pilots).
-
-## Configuration
-
-* `samsite.alltarget:` false is recommended, true makes samsite target other vehicles as well
-* `Target heli (requires alltarget):` (true/false) **doesn't work currently**
+Also prevents these SAM Sites from shooting empty vehicles.


### PR DESCRIPTION
* Added back feature to avoid targeting empty vehicles
* Remove configuration section from the documentation since the configuration was removed in a previous update